### PR TITLE
Small fix for Laravel 5.1 + Schema stubs

### DIFF
--- a/src/Commands/FileCommand.php
+++ b/src/Commands/FileCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Input\InputOption;
 class FileCommand extends GeneratorCommand
 {
 
+  use \Illuminate\Console\AppNamespaceDetectorTrait;
+
 	/**
 	 * The console command name.
 	 *

--- a/src/Migrations/SyntaxBuilder.php
+++ b/src/Migrations/SyntaxBuilder.php
@@ -133,7 +133,7 @@ class SyntaxBuilder
 	 */
 	private function getCreateSchemaWrapper()
 	{
-		return file_get_contents(__DIR__ . '/../../resources/stubs/schema-create.stub');
+		return file_get_contents(config('generators.schema_create_stub'));
 	}
 
 	/**
@@ -143,7 +143,7 @@ class SyntaxBuilder
 	 */
 	private function getChangeSchemaWrapper()
 	{
-		return file_get_contents(__DIR__ . '/../../resources/stubs/schema-change.stub');
+		return file_get_contents(config('generators.schema_change_stub'));
 	}
 
 	/**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -78,4 +78,8 @@ return [
 	'view_add_edit_stub'    => base_path() . '/vendor/bpocallaghan/generators/resources/stubs/view.add_edit.stub',
 
 	'view_show_stub'        => base_path() . '/vendor/bpocallaghan/generators/resources/stubs/view.show.stub',
+
+	'schema_create_stub'    => base_path() . '/vendor/bpocallaghan/generators/resources/stubs/schema-create.stub',
+
+	'schema_change_stub'    => base_path() . '/vendor/bpocallaghan/generators/resources/stubs/schema-change.stub',
 ];


### PR DESCRIPTION
I added a trait that is needed for Laravel 5.1 when calling `getAppNamespace()`.

Added the possibility to change the contents of the migration schema since they are exported into the stubs folder, but never taken into account.

P.S. Thanks for the extra work you did refactoring this package, only had time to get back to implementing the `2.0.*` version with my projects